### PR TITLE
Stop using fork for building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Checkout tools repo
         uses: actions/checkout@v2
         with:
-            repository: herbmc/DU-Orbital-Hud
+            repository: Dimencia/DU-Orbital-Hud
+            ref: v4.837
             path: DU-Orbital-Hud
 
       - name: Version Number


### PR DESCRIPTION
Use the upstream Dimencia code for building but target a specific release so things are in a known state.